### PR TITLE
BUG: fix error: ‘printf’ was not declared in this scope

### DIFF
--- a/llvm/extra.cpp
+++ b/llvm/extra.cpp
@@ -39,6 +39,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <sstream>
+#include <cstdio>
 
 // LLVM includes
 #include "llvm/LLVMContext.h"


### PR DESCRIPTION
See https://github.com/ContinuumIO/numba/issues/3#issuecomment-4512706

Bottom line: recent versions of gcc got stricter, one has to `#include <cstdio>` to get `printf`, etc.
