### PR TITLE
Fix broken testall.py (NameError: PASS_AGGRESSIVE_DCE)

### DIFF
--- a/test/testall.py
+++ b/test/testall.py
@@ -610,7 +610,7 @@ def do_functionpassmanager():
     b.ret(Constant.int(ti, 42))
     fpm = FunctionPassManager.new(m)
     fpm.add(TargetData.new(''))
-    fpm.add(PASS_AGGRESSIVE_DCE)
+    fpm.add(PASS_ADCE)
     fpm.initialize()
     fpm.run(f)
     fpm.finalize()


### PR DESCRIPTION
Commit 2d79cfa43 renamed PASS_AGGRESSIVE_DCE -> PASS_ADCE but missed an
instance in one test.
