### PR TITLE
test_uses: Fix unexpected keyword argument 'end' with `nosetests uses.py`

### DIFF
--- a/test/uses.py
+++ b/test/uses.py
@@ -21,7 +21,7 @@ class TestUses(unittest.TestCase):
         logging.debug(m)
         logging.debug("-"*60)
 
-        logging.debug("Testing use count ..", end=' ')
+        logging.debug("Testing use count ..")
         self.assertEqual(f.args[0].use_count, 1)
         self.assertEqual(f.args[1].use_count, 1)
         self.assertEqual(f.args[2].use_count, 1)
@@ -29,7 +29,7 @@ class TestUses(unittest.TestCase):
         self.assertEqual(tmp2.use_count, 0)
         self.assertEqual(tmp3.use_count, 1)
 
-        logging.debug("Testing uses ..", end=' ')
+        logging.debug("Testing uses ..")
         self.assertIs(f.args[0].uses[0], tmp1)
         self.assertEqual(len(f.args[0].uses), 1)
         self.assertIs(f.args[1].uses[0], tmp2)


### PR DESCRIPTION
Logging does not know about the keyword argument 'end'. The existing code works only because the default logging level prevents debug messages from running.  When running the test under `nosetests` the debug messages are enabled leading to the error.

The error can also be triggered by enabling debug logging at the top of the file:

``` python
logging.getLogger().setLevel(logging.DEBUG)
```
