### PR TITLE
setup.py remove: extra_link_args += ['-framework', 'Python']

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,8 +90,6 @@ def call_setup(llvm_config):
         std_libs.append("dl")
     if "darwin" in sys.platform:
         std_libs.append("ffi")
-        extra_link_args += ['-framework', 'Python']
-        
 
     ext_core = Extension(
         'llvm._core',


### PR DESCRIPTION
This should resolve:

https://github.com/llvmpy/llvmpy/issues/4

I ran into this while building the llvmpy module for my non-system Python install.

-Cyrus
