### PR TITLE
Implement property CallOrInvokeInstruction.called_function

### DIFF
--- a/llvm/_core.cpp
+++ b/llvm/_core.cpp
@@ -645,7 +645,7 @@ _wrap_objintenum2none(LLVMRemoveInstrAttribute, LLVMValueRef, LLVMAttribute)
 _wrap_objintint2none(LLVMSetInstrParamAlignment, LLVMValueRef)
 _wrap_obj2obj(LLVMIsTailCall, LLVMValueRef, int)
 _wrap_objint2none(LLVMSetTailCall, LLVMValueRef)
-
+_wrap_obj2obj(LLVMInstGetCalledFunction, LLVMValueRef, LLVMValueRef)
 
 /*===-- PHI Nodes --------------------------------------------------------===*/
 
@@ -1716,6 +1716,7 @@ static PyMethodDef core_methods[] = {
     _method( LLVMAddInstrAttribute )
     _method( LLVMRemoveInstrAttribute )
     _method( LLVMSetInstrParamAlignment )
+    _method( LLVMInstGetCalledFunction )
 
     /* PHI Nodes */
     _method( LLVMAddIncoming1 )

--- a/llvm/core.py
+++ b/llvm/core.py
@@ -1501,6 +1501,12 @@ class CallOrInvokeInstruction(Instruction):
     def set_parameter_alignment(self, idx, align):
         _core.LLVMSetInstrParamAlignment(self.ptr, idx, align)
 
+    @property
+    def called_function(self):
+        function = _core.LLVMInstGetCalledFunction(self.ptr)
+        if function: # Return value can be None on indirect call/invoke
+            return _make_value(function)
+
     # tail call is valid only for 'call', not 'invoke'
     # disabled for now
     #def _get_tc(self): return _core.LLVMIsTailCall(self.ptr)

--- a/llvm/extra.cpp
+++ b/llvm/extra.cpp
@@ -750,6 +750,12 @@ unsigned LLVMCmpInstGetPredicate(LLVMValueRef cmpinst)
     return instp->getPredicate();
 }
 
+LLVMValueRef LLVMInstGetCalledFunction(LLVMValueRef inst)
+{
+    llvm::Instruction *instp = llvm::unwrap<llvm::Instruction>(inst);
+    return llvm::wrap(CallSite(instp).getCalledFunction());
+}
+
 /* llvm::unwrap a set of `n' wrapped objects starting at `values',
  * into a vector of pointers to llvm::unwrapped objects `out'. */
 template <typename W, typename UW>

--- a/llvm/extra.h
+++ b/llvm/extra.h
@@ -412,6 +412,10 @@ unsigned LLVMInstGetOpcode(LLVMValueRef inst);
 /* Wraps llvm::CmpInst::getPredicate(). */
 unsigned LLVMCmpInstGetPredicate(LLVMValueRef cmpinst);
 
+/* Wraps llvm::CallSite::getCalledFunction.
+ */
+LLVMValueRef LLVMInstGetCalledFunction(LLVMValueRef inst);
+
 /* Wraps llvm::ParseAssemblyString(). Returns a module reference or NULL (with
  * `out' pointing to an error message). Dispose error message after use, via
  * LLVMDisposeMessage(). */

--- a/llvm/test_llvmpy.py
+++ b/llvm/test_llvmpy.py
@@ -61,6 +61,8 @@ entry:
         self.assertEqual(len(i1.operands), 3)
         self.assertEqual(len(i2.operands), 2)
 
+        self.assert_(i1.called_function is prod)
+
 tests.append(TestOperands)
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implement property `CallOrInvokeInstruction.called_function`, using C++ API `CallSite::getCalledFunction`.

Also add a testcase.
