### PR TITLE
Add support for module named metadata

### DIFF
--- a/llvm/_core.cpp
+++ b/llvm/_core.cpp
@@ -610,6 +610,7 @@ _wrap_objlist2obj(LLVMMetaDataGet, LLVMModuleRef, LLVMValueRef, LLVMValueRef)
 _wrap_objstrobj2none(LLVMAddNamedMetadataOperand, LLVMModuleRef, LLVMValueRef)
 _wrap_objint2obj(LLVMMetaDataGetOperand, LLVMValueRef, LLVMValueRef)
 _wrap_obj2obj(LLVMMetaDataGetNumOperands, LLVMValueRef, int)
+_wrap_objstr2obj(LLVMMetaDataStringGet, LLVMModuleRef, LLVMValueRef)
 
 static PyObject *
 _wLLVMGetNamedMetadataOperands(PyObject *self, PyObject *args)
@@ -1687,6 +1688,7 @@ static PyMethodDef core_methods[] = {
     _method( LLVMAddNamedMetadataOperand )
     _method( LLVMMetaDataGetOperand )
     _method( LLVMMetaDataGetNumOperands )
+    _method( LLVMMetaDataStringGet )
 
     /* Instructions */
     _method( LLVMGetInstructionParent )

--- a/llvm/core.py
+++ b/llvm/core.py
@@ -1478,6 +1478,17 @@ class MetaData(Value):
     def _get_operand(self, i):
         return _make_value(_core.LLVMMetaDataGetOperand(self.ptr, i))
 
+class MetaDataString(Value):
+    @staticmethod
+    def get(module, s):
+        ptr = _core.LLVMMetaDataStringGet(module.ptr, s)
+        return MetaDataString(ptr)
+
+    @property
+    def string(self):
+        '''Same as MDString::getString'''
+        return self.name
+
 #===----------------------------------------------------------------------===
 # Instruction
 #===----------------------------------------------------------------------===
@@ -1648,6 +1659,8 @@ __class_for_valueid = {
     VALUE_CONSTANT_STRUCT                 : ConstantStruct,
     VALUE_CONSTANT_VECTOR                 : ConstantVector,
     VALUE_CONSTANT_POINTER_NULL           : ConstantPointerNull,
+    VALUE_MD_NODE                         : MetaData,
+    VALUE_MD_STRING                       : MetaDataString,
     VALUE_INSTRUCTION + OPCODE_PHI        : PHINode,
     VALUE_INSTRUCTION + OPCODE_CALL       : CallOrInvokeInstruction,
     VALUE_INSTRUCTION + OPCODE_INVOKE     : CallOrInvokeInstruction,

--- a/llvm/extra.cpp
+++ b/llvm/extra.cpp
@@ -159,6 +159,13 @@ unsigned LLVMMetaDataGetNumOperands(LLVMValueRef mdref)
     return llvm::unwrap<llvm::MDNode>(mdref)->getNumOperands();
 }
 
+LLVMValueRef LLVMMetaDataStringGet(LLVMModuleRef modref, const char *s)
+{
+    LLVMContext & context = unwrap(modref)->getContext();
+    MDString * const mdstring = MDString::get(context, s);
+    return wrap(mdstring);
+}
+
 const char *LLVMGetConstExprOpcodeName(LLVMValueRef inst)
 {
     return llvm::unwrap<llvm::ConstantExpr>(inst)->getOpcodeName();

--- a/llvm/extra.h
+++ b/llvm/extra.h
@@ -76,6 +76,11 @@ LLVMValueRef LLVMMetaDataGetOperand(LLVMValueRef mdref, unsigned index);
 unsigned LLVMMetaDataGetNumOperands(LLVMValueRef mdref);
 
 /*
+ * Wraps MDString::get()
+ */
+LLVMValueRef LLVMMetaDataStringGet(LLVMModuleRef modref, const char *s);
+
+/*
  * Wraps ConstantExpr::getOpcodeName()
  */
 const char *LLVMGetConstExprOpcodeName(LLVMValueRef inst);

--- a/llvm/test_llvmpy.py
+++ b/llvm/test_llvmpy.py
@@ -16,7 +16,7 @@ else:
 
 from llvm import __version__
 from llvm.core import (Module, Type, GlobalVariable, Function, Builder,
-                       Constant, MetaData)
+                       Constant, MetaData, MetaDataString)
 import llvm.passes as lp
 import llvm.ee as le
 
@@ -395,12 +395,13 @@ class TestMetaData(unittest.TestCase):
     def test_metadata(self):
         m = Module.new('a')
         t = Type.int()
-        metadata = MetaData.get(m, [Constant.int(t, 100)])
+        metadata = MetaData.get(m, [Constant.int(t, 100), MetaDataString.get(m, 'abcdef')])
         MetaData.add_named_operand(m, 'foo', metadata)
         self.assertEqual(MetaData.get_named_operands(m, 'foo'), [metadata])
         self.assertEqual(MetaData.get_named_operands(m, 'bar'), [])
-        self.assertEqual(len(metadata.operands), 1)
+        self.assertEqual(len(metadata.operands), 2)
         self.assertEqual(metadata.operands[0].z_ext_value, 100)
+        self.assertEqual(metadata.operands[1].string, 'abcdef')
 
 tests.append(TestMetaData)
 


### PR DESCRIPTION
This is mainly useful to get access to top-level debug information through `llvm.dbg.cu`.

Wraps LLVM C-API functions `LLVMGetNamedMetadataNumOperands`, `LLVMGetNamedMetadataOperands` and `LLVMAddNamedMetadataOperand`.

Also add testcase.

I was divided between adding the functions as normal methods on `Module` or as static methods on `MetaData`. I went with the second to keep it in line with `MetaData.get`.

**2)** Also add access to MetaData operands. This is not available in the C API, so add functions to extra.cpp:
- `LLVMMetaDataGetOperand` wraps MDNode::getOperand
- `LLVMMetaDataGetNumOperands` wraps MDNode::getNumOperands

**3)** Support MetaDataString (both creation and extraction)
