### PR TITLE
MetaData operands can be None. Handle this.

### DIFF
--- a/llvm/_util.py
+++ b/llvm/_util.py
@@ -62,6 +62,11 @@ def unpack_gen(objlist, check_fn):
     for obj in objlist: check_fn(obj)
     return [ obj.ptr for obj in objlist ]
 
+def unpack_gen_allow_none(objlist, check_fn):
+    for obj in objlist:
+        if obj is not None:
+            check_fn(obj)
+    return [ (obj.ptr if obj is not None else None) for obj in objlist ]
 
 #===----------------------------------------------------------------------===
 # Helper to wrap over iterables (LLVMFirstXXX, LLVMNextXXX). This used

--- a/llvm/core.py
+++ b/llvm/core.py
@@ -296,6 +296,9 @@ def unpack_types(objlst):     return _util.unpack_gen(objlst, check_is_type)
 def unpack_values(objlst):    return _util.unpack_gen(objlst, check_is_value)
 def unpack_constants(objlst): return _util.unpack_gen(objlst, check_is_constant)
 
+def unpack_values_or_none(objlst):
+    return _util.unpack_gen_allow_none(objlst, check_is_value)
+
 def check_is_callable(obj):
     if isinstance(obj, Function):
         return
@@ -1453,7 +1456,7 @@ class Function(GlobalValue):
 class MetaData(Value):
     @staticmethod
     def get(module, values):
-        vs = unpack_values(values)
+        vs = unpack_values_or_none(values)
         ptr = _core.LLVMMetaDataGet(module.ptr, vs)
         return MetaData(ptr)
 
@@ -1476,7 +1479,9 @@ class MetaData(Value):
         return [self._get_operand(i) for i in range(self.operand_count)]
 
     def _get_operand(self, i):
-        return _make_value(_core.LLVMMetaDataGetOperand(self.ptr, i))
+        val = _core.LLVMMetaDataGetOperand(self.ptr, i)
+        if val: # metadata operands can be None
+            return _make_value(val)
 
 class MetaDataString(Value):
     @staticmethod

--- a/llvm/test_llvmpy.py
+++ b/llvm/test_llvmpy.py
@@ -558,13 +558,15 @@ class TestMetaData(unittest.TestCase):
         m = Module.new('a')
         t = Type.int()
         metadata = MetaData.get(m, [Constant.int(t, 100),
-                                    MetaDataString.get(m, 'abcdef')])
+                                    MetaDataString.get(m, 'abcdef'),
+                                    None])
         MetaData.add_named_operand(m, 'foo', metadata)
         self.assertEqual(MetaData.get_named_operands(m, 'foo'), [metadata])
         self.assertEqual(MetaData.get_named_operands(m, 'bar'), [])
-        self.assertEqual(len(metadata.operands), 2)
+        self.assertEqual(len(metadata.operands), 3)
         self.assertEqual(metadata.operands[0].z_ext_value, 100)
         self.assertEqual(metadata.operands[1].string, 'abcdef')
+        self.assertTrue(metadata.operands[2] is None)
 
 tests.append(TestMetaData)
 


### PR DESCRIPTION
When certain debug data operands (such as virtual function references) are unused, the values at that index can be None.
Currently, that causes an error when handled in llvmpy (both when emitting and parsing). This pull request makes it work.
