### PR TITLE
Wrap LLVMGetPointerToGlobal & add ExecutionEngine.get_pointer_to_global.

### DIFF
--- a/llvm/_core.cpp
+++ b/llvm/_core.cpp
@@ -1345,6 +1345,23 @@ _wLLVMGetPointerToFunction(PyObject *self, PyObject *args)
     LLVMPY_CATCH_ALL
 }
 
+static PyObject *
+_wLLVMGetPointerToGlobal(PyObject *self, PyObject *args)
+{
+    LLVMPY_TRY
+    PyObject *obj_ee;
+    PyObject *obj_val;
+
+    if (!PyArg_ParseTuple(args, "OO", &obj_ee, &obj_val))
+        return NULL;
+
+    const LLVMExecutionEngineRef ee = pycap_get<LLVMExecutionEngineRef>( obj_ee ) ;
+    const LLVMValueRef val = pycap_get<LLVMValueRef>( obj_val ) ;
+
+    return PyLong_FromVoidPtr(LLVMGetPointerToGlobal(ee, val));
+    LLVMPY_CATCH_ALL
+}
+
 /* the args should have been ptr, num */
 LLVMGenericValueRef LLVMRunFunction2(LLVMExecutionEngineRef EE,
     LLVMValueRef F, LLVMGenericValueRef *Args, unsigned NumArgs)
@@ -2168,6 +2185,7 @@ static PyMethodDef core_methods[] = {
     _method( LLVMDisposeExecutionEngine )
     _method( LLVMRunFunction2 )
     _method( LLVMGetPointerToFunction )
+    _method( LLVMGetPointerToGlobal )
     _method( LLVMGetExecutionEngineTargetData )
     _method( LLVMRunStaticConstructors )
     _method( LLVMRunStaticDestructors )

--- a/llvm/core.py
+++ b/llvm/core.py
@@ -289,6 +289,7 @@ def check_is_type_struct(obj):  _util.check_gen(obj, StructType)
 def check_is_value(obj):        _util.check_gen(obj, Value)
 def check_is_constant(obj):     _util.check_gen(obj, Constant)
 def check_is_function(obj):     _util.check_gen(obj, Function)
+def check_is_global_value(obj): _util.check_gen(obj, GlobalValue)
 def check_is_basic_block(obj):  _util.check_gen(obj, BasicBlock)
 def check_is_module(obj):       _util.check_gen(obj, Module)
 

--- a/llvm/ee.py
+++ b/llvm/ee.py
@@ -277,6 +277,10 @@ class ExecutionEngine(object):
         core.check_is_function(fn)
         return _core.LLVMGetPointerToFunction(self.ptr,fn.ptr)
 
+    def get_pointer_to_global(self, val):
+        core.check_is_global_value(val)
+        return _core.LLVMGetPointerToGlobal(self.ptr, val.ptr)
+
     def run_static_ctors(self):
         _core.LLVMRunStaticConstructors(self.ptr)
 


### PR DESCRIPTION
I needed to access a global variable in some JIT code recently and
noticed that this function had not been wrapped yet.

I just copied the similar LLVMGetPointerToFunction implementation.
