### PR TITLE
Correct if-then-else LLVM asm example.

### DIFF
--- a/docs/source/doc/kaleidoscope/PythonLangImpl5.rst
+++ b/docs/source/doc/kaleidoscope/PythonLangImpl5.rst
@@ -217,7 +217,8 @@ Kaleidoscope looks something like this:
       br i1 %ifcond, label %then, label %else 
 
    then:       ; preds = %entry 
-      %calltmp1 = call double @bar() 
+      %calltmp = call double @foo() 
+      br label %ifcont 
 
    else:       ; preds = %entry 
       %calltmp1 = call double @bar() 


### PR DESCRIPTION
As was present vividly breaks LLVM IR constraints on SSA and basic-blocks:
same var being assigned twice, no control transfer at the end of basic block.
Compare with the original:
http://www.mdevan.org/llvm-py/kaleidoscope/PythonLangImpl5.html
