### PR TITLE
Allow Retrieval of Metadata on Instructions

### DIFF
--- a/llvm/core.py
+++ b/llvm/core.py
@@ -1688,6 +1688,12 @@ class Instruction(User):
 
     def set_metadata(self, kind, metadata):
         self._ptr.setMetadata(kind, metadata._ptr)
+        
+    def has_metadata(self):
+        return self._ptr.hasMetadata()
+
+    def get_metadata(self, kind):
+        return self._ptr.getMetadata(kind)
 
     @property
     def opcode(self):


### PR DESCRIPTION
I added two methods to instructions, get_metadata(kind) and has_metadata().  The functionality already existed on the C side, but there was no way to access it from the python side.
