### PR TITLE
Fix broken tests from test refactor

### DIFF
--- a/test/inlineasm.py
+++ b/test/inlineasm.py
@@ -3,7 +3,7 @@
 # Import the llvm-py modules.
 from llvm import *
 from llvm.core import *
-from llvm.test_llvmpy import TestCase
+from llvm.tests.support import TestCase
 
 import logging
 import unittest

--- a/test/loopvectorize.py
+++ b/test/loopvectorize.py
@@ -2,7 +2,7 @@ from llvm.core import *
 from llvm.passes import *
 from llvm.ee import *
 import llvm
-from llvm.test_llvmpy import TestCase
+from llvm.tests.support import TestCase
 from os.path import dirname, join as join_path
 
 

--- a/test/metadata.py
+++ b/test/metadata.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import unittest
-from llvm.test_llvmpy import TestCase
+from llvm.tests.support import TestCase
 from llvm.core import *
 
 class TestMetaData(TestCase):

--- a/test/tbaa.py
+++ b/test/tbaa.py
@@ -1,6 +1,6 @@
 from llvm.core import *
 from llvm.tbaa import *
-from llvm.test_llvmpy import TestCase
+from llvm.tests.support import TestCase
 import unittest
 
 class TestTBAABuilder(TestCase):

--- a/test/test.py
+++ b/test/test.py
@@ -7,7 +7,7 @@ import unittest, sys, logging
 
 from llvm import *
 from llvm.core import *
-from llvm.test_llvmpy import TestCase
+from llvm.tests.support import TestCase
 
 class TestModule(TestCase):
 

--- a/test/test_debuginfo.py
+++ b/test/test_debuginfo.py
@@ -4,7 +4,7 @@ import unittest
 import llvm.ee
 from llvm.core import *
 from llvm import _dwarf, debuginfo
-from llvm.test_llvmpy import TestCase
+from llvm.tests.support import TestCase
 
 class TestDebugInfo(TestCase):
 


### PR DESCRIPTION
The test scripts in ./test are broken because llvm.test_llvmpy doesn't exist anymore.
