### PR TITLE
Issue #101: Module.from_bitcode doesn't accept bytes objects under 3.x

### DIFF
--- a/llvm/core.py
+++ b/llvm/core.py
@@ -408,7 +408,7 @@ class Module(llvm.Wrapper):
         fileobj_or_str -- takes a file-like object or string that contains
         a module represented in bitcode.
         """
-        if isinstance(fileobj_or_str, str):
+        if isinstance(fileobj_or_str, bytes):
             bc = fileobj_or_str
         else:
             bc = fileobj_or_str.read()

--- a/llvm/tests/test_asm.py
+++ b/llvm/tests/test_asm.py
@@ -12,10 +12,14 @@ class TestAsm(TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
-    def test_asm(self):
+    def create_module(self):
         # create a module
         m = Module.new('module1')
         m.add_global_variable(Type.int(), 'i')
+        return m
+
+    def test_asm_roundtrip(self):
+        m = self.create_module()
 
         # write it's assembly representation to a file
         asm = str(m)
@@ -32,13 +36,8 @@ class TestAsm(TestCase):
 
         self.assertEqual(str(m2).strip(), asm.strip())
 
-    def test_bitcode(self):
-        # create a module
-        m = Module.new('module1')
-        m.add_global_variable(Type.int(), 'i')
-
-        # write it's assembly representation to a file
-        asm = str(m)
+    def test_bitcode_roundtrip(self):
+        m = self.create_module()
 
         testasm_bc = os.path.join(self.tmpdir, 'testasm.bc')
         with open(testasm_bc, "wb") as fout:
@@ -50,7 +49,22 @@ class TestAsm(TestCase):
             # The default `m.id` is '<string>'.
             m2.id = m.id # Copy the name from `m`
 
-        self.assertEqual(str(m2).strip(), asm.strip())
+        with open(testasm_bc, "rb") as fin:
+            m3 = Module.from_bitcode(fin.read())
+            # The default `m.id` is '<string>'.
+            m3.id = m.id # Copy the name from `m`
+
+        self.assertEqual(str(m2).strip(), str(m).strip())
+        self.assertEqual(str(m3).strip(), str(m).strip())
+
+    def test_to_bitcode(self):
+        m = self.create_module()
+        testasm_bc = os.path.join(self.tmpdir, 'testasm.bc')
+        with open(testasm_bc, "wb") as fout:
+            m.to_bitcode(fout)
+        with open(testasm_bc, "rb") as fin:
+            self.assertEqual(fin.read(), m.to_bitcode())
+
 
 tests.append(TestAsm)
 


### PR DESCRIPTION
Fix for issue #101
