### PR TITLE
Fixed issue #100: Already released error

### DIFF
--- a/llvmpy/capsule.py
+++ b/llvmpy/capsule.py
@@ -222,7 +222,7 @@ class Wrapper(object):
 
     @classmethod
     def _has_dtor(cls):
-        return hasattr(cls, '_delete_')
+        return hasattr(cls, '__delete__')
 
 
 #def downcast(obj, cls):


### PR DESCRIPTION
This issue would cause running the tutorial for the kaleidoscope language to crash with the error: 
File "/usr/local/lib/python2.7/dist-packages/llvm/passes.py", line 161, in add
    self._ptr.add(pass_obj._ptr)
  File "/usr/local/lib/python2.7/dist-packages/llvmpy/api/llvm/__init__.py", line 3726, in add
    capsule.release_ownership(unwrapped1[0])
  File "/usr/local/lib/python2.7/dist-packages/llvmpy/capsule.py", line 113, in release_ownership
    raise Exception("Already released")
Exception: Already released
