### PR TITLE
BUG: the win-32 specific config file was not included in the sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include CHANGELOG LICENSE README.rst setup.py MANIFEST.in versioneer.py
+include CHANGELOG LICENSE README.rst setup.py MANIFEST.in versioneer.py llvm-config-win32.py
 recursive-include llvm *
 recursive-include llvmpy *
 recursive-include www *


### PR DESCRIPTION
This fixes the tarball for windows builds
