### PR TITLE
Version api.cpp with the Python version (e.g. api.3.4.cpp), to avoid bug...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ _build
 /llvm/_intrinsic_ids.py
 llvm_
 newbinding/api/*
+llvmpy/api*.cpp
+

--- a/llvmpy/gen/gen.py
+++ b/llvmpy/gen/gen.py
@@ -63,7 +63,8 @@ def main():
 
     # Check if files are modified
 
-    outputfilepath = '%s.cpp' % outputfilename
+    outputfilepath = '%s.%d.%d.cpp' % (outputfilename,
+                                       sys.version_info[0], sys.version_info[1])
     try:
         mtime = os.path.getmtime(outputfilepath)
     except OSError:

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ else:
 os.environ['LLVMPY_LLVM_VERSION'] = llvm_version
 os.environ['LLVM_TARGETS_BUILT'] = targets_built
 check_call([sys.executable, 'llvmpy/build.py'])
+api_file = 'llvmpy/api.%d.%d.cpp' % (sys.version_info[0], sys.version_info[1])
 
 # generate shared objects
 extra_link_args = ldflags.split()
@@ -149,7 +150,7 @@ kwds = dict(
     ext_modules=[
         Extension(
             name='llvmpy._api',
-            sources=['llvmpy/api.cpp'],
+            sources=[api_file],
             define_macros=macros,
             include_dirs=[incdir, 'llvmpy/include'],
             library_dirs=[libdir],


### PR DESCRIPTION
...s with stale api.cpp file generated by another Python version
