### PR TITLE
Bugfix for replace_all_uses_with function and feature for getting successor blocks for a BB

### DIFF
--- a/llvm/core.py
+++ b/llvm/core.py
@@ -2046,6 +2046,8 @@ class BasicBlock(Value):
     def successors(self):
         """Returns a list of successor basic blocks.
         """
+        if not hasattr(self.terminator._ptr, "getSuccessor"):
+            return []
         return list(map(_make_value, map(self.terminator._ptr.getSuccessor,
             range(0, self.terminator._ptr.getNumSuccessors()))))
 


### PR DESCRIPTION
The first patch is a bugfix for the Instruction.replace_all_uses_with function, where an invalid pointer (to the python object, not the C wrapper object) was passed.
The second patch adds a "successors" attribute to BasicBlock, which lists all basic blocks following this one.
