### PR TITLE
Fixed instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,9 @@ Quickstart
     to separate your custom build from the default system package.  Please
     replace ``LLVM_INSTALL_PATH`` with your own path.
 
+    **Note**: OSX requires to set ``CC="/usr/bin/clang" CXX="/usr/bin/clang++"``
+    before the ``./configure ...`` command.
+
 3. Run ``REQUIRES_RTTI=1 make install`` to build and install.
 
     **Note**: With LLVM 3.3, the default build configuration has C++ RTTI
@@ -42,7 +45,7 @@ Quickstart
 
    $ git clone https://github.com/llvmpy/llvmpy.git
    $ cd llvmpy
-   $ LLVM_CONFIG_PATH=LLVM_INSTALL_PATH/bin/llvm-config python setup.py install
+   $ sudo LLVM_CONFIG_PATH=LLVM_INSTALL_PATH/bin/llvm-config python setup.py install
 
    Run the tests::
 


### PR DESCRIPTION
Tried the installation on Mac OSX 10.9.4 according to your instructions when two problems occurred:

**I needed to set the compiler-paths when configuring `llvm-3.3` explicitly:**

``` Shell
./configure --enable-optimized --prefix=/Users/michaelriedel/Developer/llvm-3.3.src/build/
...
configure: error: Selected compiler could not find or parse C++ standard library headers.  Rerun with CC=c-compiler CXX=c++-compiler ./configure ...
```

**I needed to use `sudo` due some permission issues:**

``` Shell
LLVM_CONFIG_PATH=../llvm-3.3.src/Release+Asserts/bin/llvm-config python setup.py install
...
error: could not delete '/Library/Python/2.7/site-packages/llpython/__init__.py': Permission denied
```
