### PR TITLE
Added ubuntu 14.04 installation instructions to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,20 @@ Quickstart
 5. See documentation at 'http://www.llvmpy.org' and examples
    under 'test'.
 
+Ubuntu 14.04 installation instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To install llvmpy with pip on ubuntu 14.04, follow these steps:
+
+1. Make sure both the system version of llvm and version 3.3 is installed::
+
+   $ sudo apt-get install llvm llvm-3.3
+
+2. Install the non-released package of llvmpy that has support for
+   multiple versions of llvm (as described in #126)::
+
+   $ pip install https://pypi.python.org/packages/source/l/llvmpy/llvmpy-0.12.7-9-g60b512d.tar.gz
+
 Common Build Problems
 ---------------------
 


### PR DESCRIPTION
As discussed in #126, it is not possibly to install llvmpy on ubuntu 14.04 with pip with the currently released version.

This PR fixes that, by adding installation instructions to the README that describes how to install the non-released version that has support for several llvm versions on the system.

In the interest of full dislosure, I should say that my interest in llvmpy starts and ends with numba, which has now switched to llvmlite. So I made this PR just to not leave any loose ends, but I will not be around to maintain it, so you can decide if you think that makes it unsuitable for pulling.
